### PR TITLE
Configure storybook-deployer for GitHub Pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "predeploy": "cd example && yarn install && yarn run build",
     "deploy": "gh-pages -d example/build",
     "storybook": "start-storybook -p 9009",
-    "build-storybook": "build-storybook"
+    "build-storybook": "build-storybook",
+    "deploy-storybook": "storybook-to-ghpages"
   },
   "peerDependencies": {
     "react": "^16.0.0",
@@ -40,6 +41,7 @@
     "@storybook/addons": "^5.3.18",
     "@storybook/preset-create-react-app": "^3.0.0",
     "@storybook/react": "^5.3.18",
+    "@storybook/storybook-deployer": "^2.8.6",
     "babel-eslint": "^10.0.3",
     "cross-env": "^7.0.2",
     "d3-force": "^2.0.1",


### PR DESCRIPTION
This configures `storybook-deployer` for GitHub Pages. Do not merge until repository is made public.